### PR TITLE
Fixed performance issue.

### DIFF
--- a/kev/document.py
+++ b/kev/document.py
@@ -29,13 +29,19 @@ class BaseDocument(BaseSchema):
     def __init__(self, **kwargs):
         self._data = self.process_schema_kwargs(kwargs)
         self._db = self.get_db()
-        self._s3 = boto3.resource('s3')
+        self._s3_cache = None
         self._create_error_dict = kwargs.get('create_error_dict') or self._create_error_dict
         if self._create_error_dict:
             self._errors = {}
         if '_id' in self._data:
             self.set_pk(self._data['_id'])
         self._index_change_list = []
+
+    @property
+    def _s3(self):
+        if self._s3_cache is None:
+            self._s3_cache= boto3.resource('s3')
+        return self._s3_cache
 
     def __repr__(self):
         return '<{class_name}: {uni}:{id}>'.format(


### PR DESCRIPTION
```python
import timeit
from models import TestDocument


def initialization():
    kwargs = {'name': 'Arianna', 'no_subscriptions': 1, '_id': 'ffdd4d96b4:id:cloudant:testdocument', 'gpa': 4.6,
           'is_active': True, ':_doc_type': 'TestDocument', 'date_created': '2017-05-31',
           'last_updated': '2017-05-31T16:08:11Z', '_rev': '1-c2ecf55671ebe2368d9bef1185c990e6'}
    document = TestDocument(**kwargs)
    return document

print(timeit.timeit("initialization()", setup="from __main__ import initialization", number=5000))
```
16.432746789883822s

After fix.
0.24045571708120406s

p.s. It doesn't solve performance issue when backing up a bunch of documents to s3.
