### PR TITLE
Add proper support to custom endpoint_url

### DIFF
--- a/kev/backends/s3/db.py
+++ b/kev/backends/s3/db.py
@@ -21,10 +21,14 @@ class S3DB(DocDB):
         #
         session_kwargs = {k: v for k, v in kwargs.items() if k in
                           self.session_kwargs}
+        endpoint_url = None
+        if 'endpoint_url' in session_kwargs.keys():
+            endpoint_url =  session_kwargs['endpoint_url']   
+            del(session_kwargs['endpoint_url'])
         if len(session_kwargs.keys()) > 0:
             boto3.Session(**session_kwargs)
 
-        self._db = boto3.resource('s3')
+        self._db = boto3.resource('s3', endpoint_url=endpoint_url)
         self.bucket = kwargs['bucket']
         self._indexer = self._db.Bucket(self.bucket)
 


### PR DESCRIPTION
Trying to fix #42

I could not test it... 
I have a strange issue on master : 
```Python3
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/benoit/.local/share/virtualenvs/dxf_geom2d/src/kev/setup.py", line 2, in <module>
        from pip.req import parse_requirements
    ModuleNotFoundError: No module named 'pip.req'
```